### PR TITLE
fix: parse user message once

### DIFF
--- a/pages/api/openai.js
+++ b/pages/api/openai.js
@@ -18,7 +18,7 @@ export default async function handler(req, res) {
   const userMessage = req.body.payload || "";
 
   try {
-    const userPrompt = getUserPrompt(userMessage);
+    const userPrompt = userMessage;
     const functions = getFunctions();
     const messages = [userPrompt];
 


### PR DESCRIPTION
Description

Previously, while running locally, I encountered an issue where `getUserPrompt` was being called twice, resulting in the name field having the value [object Object]. After submitting, the UI displayed:

This pull request resolves this issue. Please take a look. Thank you.

Before:

<img width="746" alt="Screenshot 2024-04-23 at 13 39 16" src="https://github.com/dennisomari/nextjs-openai-boilerplate/assets/56281095/f9bc08b8-a3ab-4d4b-8f70-0c456925d1b3">


After:

<img width="643" alt="Screenshot 2024-04-23 at 13 41 40" src="https://github.com/dennisomari/nextjs-openai-boilerplate/assets/56281095/3a97d5ec-71ab-4ea0-bce3-7f3881bdcf0f">
